### PR TITLE
Properly declare dependency on SonarJava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
           <pluginName>Codehawk Java</pluginName>
           <pluginClass>org.codehawk.plugin.java.MyJavaRulesPlugin</pluginClass>
           <sonarLintSupported>true</sonarLintSupported>
+          <requirePlugins>java:6.3</requirePlugins>
           <sonarQubeMinVersion>6.7</sonarQubeMinVersion>
         </configuration>
       </plugin>


### PR DESCRIPTION
In some IDEs, SonarLint will not load SonarJava, and consequently will not load plugins having a dependency on it. If the plugin doesn't declare properly a dependency, it will be loaded, and it will crash at runtime:
```
java.lang.NoClassDefFoundError: org/sonar/plugins/java/api/CheckRegistrar
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:550)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
	at org.sonar.classloader.ClassRealm.loadClassFromSelf(ClassRealm.java:125)
	at org.sonar.classloader.ParentFirstStrategy.loadClass(ParentFirstStrategy.java:37)
	at org.sonar.classloader.ClassRealm.loadClass(ClassRealm.java:87)
	at org.sonar.classloader.ClassRealm.loadClass(ClassRealm.java:76)
	at org.codehawk.plugin.java.MyJavaRulesPlugin.define(MyJavaRulesPlugin.java:17)
```
https://community.sonarsource.com/t/error-in-sonarlint-for-pycharm-2021-1-1/42148